### PR TITLE
compose.ymlのimageを修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: ghcr.io/compose/ccgateway:v1.7.4
+    image: ghcr.io/concrnt/ccgateway:v1.7.4
     restart: always
     depends_on:
       db:
@@ -16,7 +16,7 @@ services:
       - internal
 
   api:
-    image: ghcr.io/compose/ccapi:v1.7.4
+    image: ghcr.io/concrnt/ccapi:v1.7.4
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
`compose.yml`の`image`において、`concrnt`とすべき部分が`compose`と書かれておりイメージをpullできない不具合を修正。